### PR TITLE
Add archive lambda with metrics and tests

### DIFF
--- a/cmd/archive/README.md
+++ b/cmd/archive/README.md
@@ -1,0 +1,26 @@
+# ArchiveMetrics Lambda
+
+This function moves processed files to an archive prefix and records import statistics.
+
+## Responsibilities
+1. Copy the uploaded object to `/archive/YYYY/MM/DD/` using `CopyObject`.
+2. Tag the source object with `processed=true`.
+3. Update the `FileImportManifest` item with `rowsProcessed`, `rowsFailed` and `status`.
+4. Emit CloudWatch metrics for `RowsProcessed`, `RowsFailed` and `ArchiveLatencyMs`.
+
+The handler is idempotent. If an object is already tagged `processed=true` it exits without error.
+
+### IAM least privilege
+| Action | Resource |
+|-------|---------|
+| `s3:GetObjectTagging` `s3:PutObjectTagging` `s3:CopyObject` | source bucket objects |
+| `dynamodb:UpdateItem` | manifest table item |
+| `cloudwatch:PutMetricData` | custom metrics namespace |
+
+## Flow
+```mermaid
+flowchart TD
+    A[CopyObject] --> B[Tag Source]
+    B --> C[Update Manifest]
+    C --> D[Emit Metrics]
+```

--- a/cmd/archive/main.go
+++ b/cmd/archive/main.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -14,53 +18,119 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	dbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"go.uber.org/zap"
 )
 
+type s3API interface {
+	GetObjectTagging(context.Context, *s3.GetObjectTaggingInput, ...func(*s3.Options)) (*s3.GetObjectTaggingOutput, error)
+	CopyObject(context.Context, *s3.CopyObjectInput, ...func(*s3.Options)) (*s3.CopyObjectOutput, error)
+	PutObjectTagging(context.Context, *s3.PutObjectTaggingInput, ...func(*s3.Options)) (*s3.PutObjectTaggingOutput, error)
+}
+
+type dbAPI interface {
+	UpdateItem(context.Context, *dynamodb.UpdateItemInput, ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+}
+
+type cwAPI interface {
+	PutMetricData(context.Context, *cloudwatch.PutMetricDataInput, ...func(*cloudwatch.Options)) (*cloudwatch.PutMetricDataOutput, error)
+}
+
 var (
-	s3Client *s3.Client
-	dbClient *dynamodb.Client
-	cwClient *cloudwatch.Client
+	s3Client s3API
+	dbClient dbAPI
+	cwClient cwAPI
 	table    = os.Getenv("MANIFEST_TABLE")
 	log      *zap.SugaredLogger
+	now      = time.Now
 )
 
-func handler(ctx context.Context, evt events.S3Event) error {
+type ArchiveEvent struct {
+	events.S3Event
+	RowsProcessed int `json:"rowsProcessed"`
+	RowsFailed    int `json:"rowsFailed"`
+}
+
+func handler(ctx context.Context, evt ArchiveEvent) error {
 	rec := evt.Records[0]
 	bucket := rec.S3.Bucket.Name
 	key := rec.S3.Object.Key
-	archiveKey := "archive/" + key
-	_, err := s3Client.CopyObject(ctx, &s3.CopyObjectInput{
+
+	tagOut, err := s3Client.GetObjectTagging(ctx, &s3.GetObjectTaggingInput{Bucket: &bucket, Key: &key})
+	if err != nil {
+		return fmt.Errorf("get tagging: %w", err)
+	}
+	for _, t := range tagOut.TagSet {
+		if strings.EqualFold(aws.ToString(t.Key), "processed") && strings.EqualFold(aws.ToString(t.Value), "true") {
+			log.Infow("already archived", "key", key)
+			return nil
+		}
+	}
+
+	archiveKey := fmt.Sprintf("archive/%s/%s", now().UTC().Format("2006/01/02"), key)
+	start := time.Now()
+	_, err = s3Client.CopyObject(ctx, &s3.CopyObjectInput{
 		Bucket:     &bucket,
 		CopySource: aws.String(bucket + "/" + key),
 		Key:        &archiveKey,
 	})
 	if err != nil {
-		return fmt.Errorf("copy object: %w", err)
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "SlowDown" {
+			time.Sleep(200 * time.Millisecond)
+			if _, err = s3Client.CopyObject(ctx, &s3.CopyObjectInput{Bucket: &bucket, CopySource: aws.String(bucket + "/" + key), Key: &archiveKey}); err != nil {
+				return fmt.Errorf("copy object retry: %w", err)
+			}
+		} else {
+			return fmt.Errorf("copy object: %w", err)
+		}
 	}
+	latency := time.Since(start).Milliseconds()
+
+	_, err = s3Client.PutObjectTagging(ctx, &s3.PutObjectTaggingInput{
+		Bucket:  &bucket,
+		Key:     &key,
+		Tagging: &s3types.Tagging{TagSet: []s3types.Tag{{Key: aws.String("processed"), Value: aws.String("true")}}},
+	})
+	if err != nil {
+		return fmt.Errorf("tag source: %w", err)
+	}
+
 	_, err = dbClient.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: &table,
 		Key: map[string]dbtypes.AttributeValue{
 			"FileKey": &dbtypes.AttributeValueMemberS{Value: key},
 		},
-		UpdateExpression: aws.String("SET Processed = :t"),
+		UpdateExpression:         aws.String("SET rowsProcessed=:rp, rowsFailed=:rf, #S=:s"),
+		ExpressionAttributeNames: map[string]string{"#S": "status"},
 		ExpressionAttributeValues: map[string]dbtypes.AttributeValue{
-			":t": &dbtypes.AttributeValueMemberBOOL{Value: true},
+			":rp": &dbtypes.AttributeValueMemberN{Value: strconv.Itoa(evt.RowsProcessed)},
+			":rf": &dbtypes.AttributeValueMemberN{Value: strconv.Itoa(evt.RowsFailed)},
+			":s":  &dbtypes.AttributeValueMemberS{Value: "ARCHIVED"},
 		},
+		ConditionExpression: aws.String("attribute_not_exists(#S) OR #S <> :s"),
 	})
 	if err != nil {
+		var cfe *dbtypes.ConditionalCheckFailedException
+		if errors.As(err, &cfe) {
+			return fmt.Errorf("manifest already archived")
+		}
 		return fmt.Errorf("update manifest: %w", err)
 	}
+
 	_, err = cwClient.PutMetricData(ctx, &cloudwatch.PutMetricDataInput{
 		Namespace: aws.String("FileProcessor"),
 		MetricData: []cwtypes.MetricDatum{
-			{MetricName: aws.String("Processed"), Value: aws.Float64(1)},
+			{MetricName: aws.String("RowsProcessed"), Value: aws.Float64(float64(evt.RowsProcessed))},
+			{MetricName: aws.String("RowsFailed"), Value: aws.Float64(float64(evt.RowsFailed))},
+			{MetricName: aws.String("ArchiveLatencyMs"), Value: aws.Float64(float64(latency)), Unit: cwtypes.StandardUnitMilliseconds},
 		},
 	})
 	if err != nil {
 		return fmt.Errorf("metrics: %w", err)
 	}
-	log.Infow("archived", "key", key)
+	log.Infow("archived", "key", key, "dest", archiveKey)
 	return nil
 }
 

--- a/cmd/archive/main_test.go
+++ b/cmd/archive/main_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+	"go.uber.org/zap"
+)
+
+type fakeS3 struct {
+	copyErr   error
+	copyCalls int
+}
+
+func (f *fakeS3) GetObjectTagging(ctx context.Context, in *s3.GetObjectTaggingInput, opt ...func(*s3.Options)) (*s3.GetObjectTaggingOutput, error) {
+	return &s3.GetObjectTaggingOutput{}, nil
+}
+
+func (f *fakeS3) CopyObject(ctx context.Context, in *s3.CopyObjectInput, opt ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
+	f.copyCalls++
+	if f.copyCalls == 1 && f.copyErr != nil {
+		return nil, f.copyErr
+	}
+	return &s3.CopyObjectOutput{}, nil
+}
+
+func (f *fakeS3) PutObjectTagging(ctx context.Context, in *s3.PutObjectTaggingInput, opt ...func(*s3.Options)) (*s3.PutObjectTaggingOutput, error) {
+	return &s3.PutObjectTaggingOutput{}, nil
+}
+
+type fakeDB struct {
+	err error
+}
+
+func (f *fakeDB) UpdateItem(ctx context.Context, in *dynamodb.UpdateItemInput, opt ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+type fakeCW struct{ called bool }
+
+func (f *fakeCW) PutMetricData(ctx context.Context, in *cloudwatch.PutMetricDataInput, opt ...func(*cloudwatch.Options)) (*cloudwatch.PutMetricDataOutput, error) {
+	f.called = true
+	return &cloudwatch.PutMetricDataOutput{}, nil
+}
+
+func TestHandlerSuccess(t *testing.T) {
+	s3Client = &fakeS3{}
+	dbClient = &fakeDB{}
+	cw := &fakeCW{}
+	cwClient = cw
+	log = zap.NewNop().Sugar()
+	now = func() time.Time { return time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC) }
+
+	evt := ArchiveEvent{RowsProcessed: 5, RowsFailed: 1}
+	evt.Records = []events.S3EventRecord{{S3: events.S3Entity{Bucket: events.S3Bucket{Name: "b"}, Object: events.S3Object{Key: "k"}}}}
+
+	if err := handler(context.Background(), evt); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !cw.called {
+		t.Fatalf("metric not sent")
+	}
+}
+
+func TestHandlerSlowdownRetry(t *testing.T) {
+	apiErr := &smithy.GenericAPIError{Code: "SlowDown", Message: "slow"}
+	fs3 := &fakeS3{copyErr: apiErr}
+	s3Client = fs3
+	dbClient = &fakeDB{}
+	cwClient = &fakeCW{}
+	log = zap.NewNop().Sugar()
+	now = func() time.Time { return time.Time{} }
+
+	evt := ArchiveEvent{}
+	evt.Records = []events.S3EventRecord{{S3: events.S3Entity{Bucket: events.S3Bucket{Name: "b"}, Object: events.S3Object{Key: "k"}}}}
+
+	if err := handler(context.Background(), evt); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if fs3.copyCalls != 2 {
+		t.Fatalf("expected 2 copy calls, got %d", fs3.copyCalls)
+	}
+}
+
+func TestHandlerConditionalFailure(t *testing.T) {
+	s3Client = &fakeS3{}
+	dbClient = &fakeDB{err: &dbtypes.ConditionalCheckFailedException{}}
+	cwClient = &fakeCW{}
+	log = zap.NewNop().Sugar()
+	now = func() time.Time { return time.Time{} }
+
+	evt := ArchiveEvent{}
+	evt.Records = []events.S3EventRecord{{S3: events.S3Entity{Bucket: events.S3Bucket{Name: "b"}, Object: events.S3Object{Key: "k"}}}}
+
+	if err := handler(context.Background(), evt); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- implement ArchiveMetrics Lambda with robust error handling
- add unit tests for ArchiveMetrics
- document ArchiveMetrics responsibilities and IAM permissions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6875daf79608832898596d33ecad98e1