### PR TITLE
Refactor guardduplicate with tests and docs

### DIFF
--- a/cmd/guardduplicate/README.md
+++ b/cmd/guardduplicate/README.md
@@ -1,0 +1,40 @@
+# GuardDuplicate
+
+This Lambda validates new S3 objects before they enter the file processing pipeline. It rejects files larger than 50&nbsp;MB, computes a SHA‑256 checksum and records the result in DynamoDB.
+
+## Flow
+1. Triggered by `ObjectCreated` events from S3.
+2. Downloads the object and calculates its SHA‑256 digest.
+3. Writes an item to the manifest table containing the file key and checksum.
+
+## S3 Event Input
+```json
+{
+  "Records": [
+    {
+      "s3": {
+        "bucket": {"name": "source-bucket"},
+        "object": {"key": "example.csv", "size": 123}
+      }
+    }
+  ]
+}
+```
+
+## Environment Variables
+- `MANIFEST_TABLE` – DynamoDB table where file manifests are stored.
+
+## Output
+A new item is inserted into the manifest table with fields `FileKey`, `SHA256` and `Processed=false`. A structured log entry `{"msg":"manifest updated","key":"<file>","sha":"<digest>"}` is emitted.
+
+## Diagram
+```mermaid
+flowchart TD
+    A[S3 ObjectCreated] --> B[GuardDuplicate]
+    B --> C{size <= 50MB?}
+    C -- no --> D[return error]
+    C -- yes --> E[GetObject]
+    E --> F[SHA-256]
+    F --> G[PutItem Dynamo]
+```
+```

--- a/cmd/guardduplicate/main.go
+++ b/cmd/guardduplicate/main.go
@@ -2,26 +2,35 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.uber.org/zap"
+
+	"github.com/your-org/file-processor-sample/internal/guard"
 )
 
-const maxSize = 50 * 1024 * 1024
+var (
+	start      = lambda.Start
+	loadConfig = config.LoadDefaultConfig
+)
+
+type s3API interface {
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}
+
+type ddbAPI interface {
+	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+}
 
 var (
-	s3Client  *s3.Client
-	dbClient  *dynamodb.Client
+	s3Client  s3API
+	dbClient  guard.PutItemAPI
 	tableName = os.Getenv("MANIFEST_TABLE")
 	log       *zap.SugaredLogger
 )
@@ -31,42 +40,32 @@ func handler(ctx context.Context, evt events.S3Event) error {
 	bucket := rec.S3.Bucket.Name
 	key := rec.S3.Object.Key
 	size := rec.S3.Object.Size
-	if size > maxSize {
-		return fmt.Errorf("file %s too large: %d", key, size)
+
+	if err := guard.ValidateSize(key, size); err != nil {
+		return err
 	}
 
 	obj, err := s3Client.GetObject(ctx, &s3.GetObjectInput{Bucket: &bucket, Key: &key})
 	if err != nil {
 		return fmt.Errorf("get object: %w", err)
 	}
-	defer func() {
-		if cerr := obj.Body.Close(); cerr != nil {
-			log.Warnw("close body", "error", cerr)
-		}
-	}()
-	h := sha256.New()
-	if _, err := io.Copy(h, obj.Body); err != nil {
+	defer guard.Close(obj.Body, log)
+
+	sum, err := guard.ComputeSHA256(obj.Body)
+	if err != nil {
 		return fmt.Errorf("read object: %w", err)
 	}
-	sum := hex.EncodeToString(h.Sum(nil))
 
-	_, err = dbClient.PutItem(ctx, &dynamodb.PutItemInput{
-		TableName: &tableName,
-		Item: map[string]types.AttributeValue{
-			"FileKey":   &types.AttributeValueMemberS{Value: key},
-			"SHA256":    &types.AttributeValueMemberS{Value: sum},
-			"Processed": &types.AttributeValueMemberBOOL{Value: false},
-		},
-	})
-	if err != nil {
+	if err := guard.PutManifest(ctx, dbClient, tableName, key, sum); err != nil {
 		return fmt.Errorf("write manifest: %w", err)
 	}
+
 	log.Infow("manifest updated", "key", key, "sha", sum)
 	return nil
 }
 
 func main() {
-	cfg, err := config.LoadDefaultConfig(context.Background())
+	cfg, err := loadConfig(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -74,5 +73,5 @@ func main() {
 	log = logger.Sugar()
 	s3Client = s3.NewFromConfig(cfg)
 	dbClient = dynamodb.NewFromConfig(cfg)
-	lambda.Start(handler)
+	start(handler)
 }

--- a/cmd/guardduplicate/main_test.go
+++ b/cmd/guardduplicate/main_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/your-org/file-processor-sample/internal/guard"
+	"go.uber.org/zap"
+)
+
+type stubBody struct {
+	io.Reader
+	closed bool
+	err    error
+}
+
+func (s *stubBody) Close() error { s.closed = true; return s.err }
+
+// --- s3 stub ---
+type stubS3 struct {
+	out   *stubBody
+	err   error
+	input *string
+}
+
+func (s *stubS3) GetObject(ctx context.Context, in *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	s.input = in.Key
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &s3.GetObjectOutput{Body: s.out}, nil
+}
+
+// --- dynamo stub ---
+type stubDDB struct {
+	putErr error
+	item   map[string]types.AttributeValue
+}
+
+func (d *stubDDB) PutItem(ctx context.Context, in *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	d.item = in.Item
+	if d.putErr != nil {
+		return nil, d.putErr
+	}
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+func newEvent(size int64) events.S3Event {
+	return events.S3Event{Records: []events.S3EventRecord{{S3: events.S3Entity{Bucket: events.S3Bucket{Name: "b"}, Object: events.S3Object{Key: "k", Size: size}}}}}
+}
+
+func setup(s3c s3API, db ddbAPI) {
+	tableName = "tbl"
+	s3Client = s3c
+	dbClient = db
+	log = zap.NewNop().Sugar()
+}
+
+func TestHandlerTooLarge(t *testing.T) {
+	setup(nil, nil)
+	evt := newEvent(guard.MaxSize + 1)
+	if err := handler(context.Background(), evt); err == nil {
+		t.Fatalf("expected size error")
+	}
+}
+
+func TestHandlerGetObjectError(t *testing.T) {
+	s3c := &stubS3{err: errors.New("boom")}
+	setup(s3c, nil)
+	evt := newEvent(1)
+	if err := handler(context.Background(), evt); err == nil || err.Error() != "get object: boom" {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestHandlerReadError(t *testing.T) {
+	body := &stubBody{Reader: &errorReader{}}
+	s3c := &stubS3{out: body}
+	setup(s3c, nil)
+	evt := newEvent(1)
+	if err := handler(context.Background(), evt); err == nil || err.Error() != "read object: read err" {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !body.closed {
+		t.Fatalf("body not closed")
+	}
+}
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) { return 0, errors.New("read err") }
+
+func TestHandlerPutError(t *testing.T) {
+	body := &stubBody{Reader: bytes.NewBufferString("ok")}
+	s3c := &stubS3{out: body}
+	db := &stubDDB{putErr: errors.New("bad")}
+	setup(s3c, db)
+	evt := newEvent(1)
+	if err := handler(context.Background(), evt); err == nil || err.Error() != "write manifest: bad" {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !body.closed {
+		t.Fatalf("body not closed")
+	}
+}
+
+func TestHandlerSuccess(t *testing.T) {
+	body := &stubBody{Reader: bytes.NewBufferString("data"), err: errors.New("c")}
+	s3c := &stubS3{out: body}
+	db := &stubDDB{}
+	setup(s3c, db)
+	evt := newEvent(1)
+	if err := handler(context.Background(), evt); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !body.closed {
+		t.Fatalf("body not closed")
+	}
+	if _, ok := db.item["SHA256"]; !ok {
+		t.Fatalf("ddb not called")
+	}
+}
+
+func TestMainFunc(t *testing.T) {
+	os.Setenv("AWS_REGION", "us-east-1")
+	os.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	called := false
+	start = func(i interface{}) { called = true }
+	loadConfig = func(ctx context.Context, optFns ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{}, nil
+	}
+	main()
+	if !called {
+		t.Fatalf("start not called")
+	}
+}
+
+func TestMainFuncError(t *testing.T) {
+	start = func(i interface{}) {}
+	loadConfig = func(ctx context.Context, optFns ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{}, errors.New("cfg")
+	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic")
+		}
+	}()
+	main()
+}

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -1,0 +1,58 @@
+package guard
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"go.uber.org/zap"
+)
+
+// MaxSize is the maximum allowed file size in bytes.
+const MaxSize int64 = 50 * 1024 * 1024
+
+// PutItemAPI abstracts the DynamoDB PutItem operation.
+type PutItemAPI interface {
+	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+}
+
+// ValidateSize returns an error if the provided size exceeds MaxSize.
+func ValidateSize(key string, size int64) error {
+	if size > MaxSize {
+		return fmt.Errorf("file %s too large: %d", key, size)
+	}
+	return nil
+}
+
+// ComputeSHA256 reads from r and returns its SHA-256 hex digest.
+func ComputeSHA256(r io.Reader) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// PutManifest writes the file key and checksum to DynamoDB.
+func PutManifest(ctx context.Context, db PutItemAPI, table, key, sum string) error {
+	_, err := db.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: &table,
+		Item: map[string]types.AttributeValue{
+			"FileKey":   &types.AttributeValueMemberS{Value: key},
+			"SHA256":    &types.AttributeValueMemberS{Value: sum},
+			"Processed": &types.AttributeValueMemberBOOL{Value: false},
+		},
+	})
+	return err
+}
+
+// Close closes c and logs any returned error.
+func Close(c io.Closer, log *zap.SugaredLogger) {
+	if err := c.Close(); err != nil {
+		log.Warnw("close body", "error", err)
+	}
+}


### PR DESCRIPTION
## Summary
- refactor cmd/guardduplicate into clearer structure using helper functions
- add internal/guard package with reusable helpers
- emit structured logging and allow injection for testing
- provide 100% tested handler using stubbed services
- document GuardDuplicate behaviour

## Testing
- `go test ./...`
- `go test ./cmd/guardduplicate -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_6875daed08388328936eff773ad32593