### PR TITLE
Add streaming parser lambda with tests

### DIFF
--- a/cmd/parsefile/README.md
+++ b/cmd/parsefile/README.md
@@ -1,0 +1,31 @@
+# ParseFile Lambda
+
+This function reads an object from S3, parses it using a plug-in parser and returns
+row data or S3 keys for JSONL chunks. The handler signature is:
+
+```go
+func handler(ctx context.Context, evt events.S3Event) (Output, error)
+```
+
+`PARSER_ID` chooses the plug-in (`csv_pipe`, `fixed_width`, `xlsx_sheet`).
+`PROFILE_JSON` supplies required columns:
+
+```json
+{
+  "required": ["header1", "header2"]
+}
+```
+
+## I/O contract
+- **Input**: `events.S3Event`
+- **Output**: `Output` with `Rows` or uploaded chunk keys and `BadRows` count.
+
+```mermaid
+sequenceDiagram
+    participant S3
+    participant PF as ParseFile
+    participant SF as Row-SFN
+    S3->>PF: Object Created Event
+    PF-->>S3: (optional) JSONL chunks
+    PF-->>SF: Rows or keys
+```

--- a/cmd/parsefile/main.go
+++ b/cmd/parsefile/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"plugin"
 	"strings"
@@ -17,31 +18,46 @@ import (
 	"go.uber.org/zap"
 )
 
-const chunkSize = 1000
+const (
+	chunkSize = 1000
+	maxMemory = 25 * 1024 * 1024
+)
 
-type Parser interface {
-	Parse(io.Reader) ([]map[string]string, error)
+type parseFunc func(io.Reader) ([]map[string]string, error)
+
+type s3API interface {
+	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
 }
 
 var (
-	s3Client *s3.Client
+	s3Client s3API
 	log      *zap.SugaredLogger
 )
 
-func loadParser(path string) (Parser, error) {
+func getParserID() string {
+	id := os.Getenv("PARSER_ID")
+	if id == "" {
+		id = "csv_pipe"
+	}
+	return id
+}
+
+func loadParser(id string) (parseFunc, error) {
+	path := fmt.Sprintf("/opt/plugins/%s.so", id)
 	p, err := plugin.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open plugin: %w", err)
 	}
-	sym, err := p.Lookup("Parser")
+	sym, err := p.Lookup("Parse")
 	if err != nil {
-		return nil, fmt.Errorf("lookup Parser: %w", err)
+		return nil, fmt.Errorf("lookup Parse: %w", err)
 	}
-	parser, ok := sym.(Parser)
+	fn, ok := sym.(func(io.Reader) ([]map[string]string, error))
 	if !ok {
 		return nil, fmt.Errorf("invalid parser type")
 	}
-	return parser, nil
+	return parseFunc(fn), nil
 }
 
 func trimRows(rows []map[string]string) {
@@ -52,13 +68,69 @@ func trimRows(rows []map[string]string) {
 	}
 }
 
-func handler(ctx context.Context, evt events.S3Event) error {
+type profileSpec struct {
+	Required []string `json:"required"`
+}
+
+func loadProfile() (profileSpec, error) {
+	v := os.Getenv("PROFILE_JSON")
+	if v == "" {
+		return profileSpec{}, nil
+	}
+	var p profileSpec
+	if err := json.Unmarshal([]byte(v), &p); err != nil {
+		return profileSpec{}, fmt.Errorf("decode profile: %w", err)
+	}
+	return p, nil
+}
+
+func validateHeader(rows []map[string]string, req []string) error {
+	if len(rows) == 0 {
+		return fmt.Errorf("no rows")
+	}
+	for _, c := range req {
+		if _, ok := rows[0][c]; !ok {
+			return fmt.Errorf("missing column %s", c)
+		}
+	}
+	return nil
+}
+
+func filterRows(rows []map[string]string, req []string) ([]map[string]string, int) {
+	var out []map[string]string
+	bad := 0
+	for _, r := range rows {
+		valid := true
+		for _, c := range req {
+			if strings.TrimSpace(r[c]) == "" {
+				valid = false
+				break
+			}
+		}
+		if valid {
+			out = append(out, r)
+		} else {
+			bad++
+		}
+	}
+	return out, bad
+}
+
+type Output struct {
+	Rows    []map[string]string `json:"rows,omitempty"`
+	Keys    []string            `json:"keys,omitempty"`
+	BadRows int                 `json:"badRows"`
+}
+
+func handler(ctx context.Context, evt events.S3Event) (Output, error) {
 	rec := evt.Records[0]
 	bucket := rec.S3.Bucket.Name
 	key := rec.S3.Object.Key
+	size := rec.S3.Object.Size
+
 	obj, err := s3Client.GetObject(ctx, &s3.GetObjectInput{Bucket: &bucket, Key: &key})
 	if err != nil {
-		return fmt.Errorf("get object: %w", err)
+		return Output{}, fmt.Errorf("get object: %w", err)
 	}
 	defer func() {
 		if cerr := obj.Body.Close(); cerr != nil {
@@ -66,17 +138,32 @@ func handler(ctx context.Context, evt events.S3Event) error {
 		}
 	}()
 
-	parser, err := loadParser("/opt/plugins/csv_pipe.so")
+	parser, err := loadParser(getParserID())
 	if err != nil {
-		return err
+		return Output{}, err
 	}
-	rows, err := parser.Parse(obj.Body)
+	rows, err := parser(obj.Body)
 	if err != nil {
-		return fmt.Errorf("parse: %w", err)
+		return Output{}, fmt.Errorf("parse: %w", err)
 	}
 	trimRows(rows)
 
+	prof, err := loadProfile()
+	if err != nil {
+		return Output{}, err
+	}
+	if err := validateHeader(rows, prof.Required); err != nil {
+		return Output{}, err
+	}
+	rows, bad := filterRows(rows, prof.Required)
+
+	if size <= maxMemory {
+		log.Infow("processed", "key", key, "rows", len(rows), "bad", bad)
+		return Output{Rows: rows, BadRows: bad}, nil
+	}
+
 	baseKey := strings.TrimSuffix(key, filepath.Ext(key))
+	var keys []string
 	for i := 0; i < len(rows); i += chunkSize {
 		end := i + chunkSize
 		if end > len(rows) {
@@ -90,20 +177,26 @@ func handler(ctx context.Context, evt events.S3Event) error {
 		}
 		outKey := fmt.Sprintf("%s_%d.jsonl", baseKey, i/chunkSize)
 		if _, err := s3Client.PutObject(ctx, &s3.PutObjectInput{Bucket: &bucket, Key: &outKey, Body: bytes.NewReader(buf.Bytes())}); err != nil {
-			return fmt.Errorf("put chunk: %w", err)
+			return Output{}, fmt.Errorf("put chunk: %w", err)
 		}
+		keys = append(keys, outKey)
 	}
-	log.Infow("processed", "key", key, "rows", len(rows))
-	return nil
+	log.Infow("processed", "key", key, "chunks", len(keys), "bad", bad)
+	return Output{Keys: keys, BadRows: bad}, nil
 }
 
-func main() {
+var lambdaStart = func(h interface{}) {
+	lambda.Start(h)
+}
+
+func run() error {
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
-		panic(err)
+		return err
 	}
 	logger, _ := zap.NewProduction()
 	log = logger.Sugar()
 	s3Client = s3.NewFromConfig(cfg)
-	lambda.Start(handler)
+	lambdaStart(handler)
+	return nil
 }

--- a/cmd/parsefile/main.go
+++ b/cmd/parsefile/main.go
@@ -189,8 +189,10 @@ var lambdaStart = func(h interface{}) {
 	lambda.Start(h)
 }
 
+var loadConfig = config.LoadDefaultConfig
+
 func run() error {
-	cfg, err := config.LoadDefaultConfig(context.Background())
+	cfg, err := loadConfig(context.Background())
 	if err != nil {
 		return err
 	}

--- a/cmd/parsefile/main_prod.go
+++ b/cmd/parsefile/main_prod.go
@@ -1,0 +1,11 @@
+//go:build lambda
+
+package main
+
+import "github.com/aws/aws-lambda-go/lambda"
+
+func main() {
+	if err := run(); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/parsefile/main_test.go
+++ b/cmd/parsefile/main_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"go.uber.org/zap"
+)
+
+type fakeS3 struct {
+	objects map[string][]byte
+	puts    map[string][]byte
+}
+
+func (f *fakeS3) GetObject(ctx context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	b, ok := f.objects[*in.Key]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(b))}, nil
+}
+
+func (f *fakeS3) PutObject(ctx context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if f.puts == nil {
+		f.puts = map[string][]byte{}
+	}
+	b, err := io.ReadAll(in.Body)
+	if err != nil {
+		return nil, err
+	}
+	f.puts[*in.Key] = b
+	return &s3.PutObjectOutput{}, nil
+}
+
+const pluginSrc = `package main
+import (
+    "fmt"
+    "io"
+    "strings"
+)
+
+func Parse(r io.Reader) ([]map[string]string, error) {
+    b, err := io.ReadAll(r)
+    if err != nil {
+        return nil, err
+    }
+    lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+    if len(lines) == 0 {
+        return nil, nil
+    }
+    hdr := strings.Split(lines[0], "|")
+    var rows []map[string]string
+    for _, line := range lines[1:] {
+        if line == "" {continue}
+        cols := strings.Split(line, "|")
+        if len(cols) != len(hdr) {
+            return nil, fmt.Errorf("malformed")
+        }
+        m := make(map[string]string)
+        for i, h := range hdr {
+            m[h] = cols[i]
+        }
+        rows = append(rows, m)
+    }
+    return rows, nil
+}
+`
+
+func buildPlugin(t *testing.T, id string) {
+	dir := "/opt/plugins"
+	os.MkdirAll(dir, 0755)
+	src := filepath.Join(t.TempDir(), "p.go")
+	os.WriteFile(src, []byte(pluginSrc), 0644)
+	out := filepath.Join(dir, id+".so")
+	cmd := exec.Command("go", "build", "-buildmode=plugin", "-o", out, src)
+	if outb, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("plugin build: %v\n%s", err, outb)
+	}
+}
+
+func newEvent(key string, size int64) events.S3Event {
+	return events.S3Event{Records: []events.S3EventRecord{{S3: events.S3Entity{Bucket: events.S3Bucket{Name: "b"}, Object: events.S3Object{Key: key, Size: size}}}}}
+}
+
+func TestHandler(t *testing.T) {
+	log = zap.NewNop().Sugar()
+	buildPlugin(t, "csv_pipe")
+
+	t.Run("small", func(t *testing.T) {
+		os.Setenv("PARSER_ID", "csv_pipe")
+		os.Setenv("PROFILE_JSON", `{"required":["header1","header2"]}`)
+		f := &fakeS3{objects: map[string][]byte{"f.qns": []byte("header1|header2\n v1 | v2 ")}}
+		s3Client = f
+		out, err := handler(context.Background(), newEvent("f.qns", 10))
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if len(out.Rows) != 1 || out.BadRows != 0 || len(out.Keys) != 0 {
+			t.Fatalf("unexpected output: %+v", out)
+		}
+	})
+
+	t.Run("large", func(t *testing.T) {
+		var sb strings.Builder
+		sb.WriteString("header1|header2\n")
+		for i := 0; i < 2500; i++ {
+			sb.WriteString(fmt.Sprintf("a%03d|b%03d\n", i, i))
+		}
+		f := &fakeS3{objects: map[string][]byte{"big.qns": []byte(sb.String())}}
+		s3Client = f
+		os.Setenv("PROFILE_JSON", `{"required":["header1","header2"]}`)
+		out, err := handler(context.Background(), newEvent("big.qns", 30000000))
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if len(out.Keys) != 3 || out.BadRows != 0 || len(out.Rows) != 0 {
+			t.Fatalf("unexpected output: %+v", out)
+		}
+		if len(f.puts) != 3 {
+			t.Fatalf("expected 3 chunks, got %d", len(f.puts))
+		}
+	})
+
+	t.Run("missing column", func(t *testing.T) {
+		f := &fakeS3{objects: map[string][]byte{"bad.qns": []byte("header1\nval")}}
+		s3Client = f
+		os.Setenv("PROFILE_JSON", `{"required":["header1","header2"]}`)
+		if _, err := handler(context.Background(), newEvent("bad.qns", 10)); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		f := &fakeS3{objects: map[string][]byte{"m.qns": []byte("header1|header2\nval1")}}
+		s3Client = f
+		os.Setenv("PROFILE_JSON", `{"required":[]}`)
+		if _, err := handler(context.Background(), newEvent("m.qns", 10)); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestRun(t *testing.T) {
+	called := false
+	lambdaStart = func(i interface{}) { called = true }
+	if err := run(); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if !called {
+		t.Fatal("start not called")
+	}
+}

--- a/cmd/parsefile/main_test.go
+++ b/cmd/parsefile/main_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.uber.org/zap"
 )
@@ -19,9 +21,14 @@ import (
 type fakeS3 struct {
 	objects map[string][]byte
 	puts    map[string][]byte
+	getErr  error
+	putErr  error
 }
 
 func (f *fakeS3) GetObject(ctx context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
 	b, ok := f.objects[*in.Key]
 	if !ok {
 		return nil, fmt.Errorf("not found")
@@ -30,6 +37,9 @@ func (f *fakeS3) GetObject(ctx context.Context, in *s3.GetObjectInput, _ ...func
 }
 
 func (f *fakeS3) PutObject(ctx context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if f.putErr != nil {
+		return nil, f.putErr
+	}
 	if f.puts == nil {
 		f.puts = map[string][]byte{}
 	}
@@ -75,17 +85,25 @@ func Parse(r io.Reader) ([]map[string]string, error) {
 }
 `
 
-func buildPlugin(t *testing.T, id string) {
-       dir := "/opt/plugins"
-       if err := os.MkdirAll(dir, 0755); err != nil {
-               t.Fatalf("mkdir: %v", err)
-       }
-       src := filepath.Join(t.TempDir(), "p.go")
-       if err := os.WriteFile(src, []byte(pluginSrc), 0644); err != nil {
-               t.Fatalf("write plugin: %v", err)
-       }
+const badPluginSrc = `package main
+func Parse() {}
+`
+
+const noSymPluginSrc = `package main
+func NotParse() {}
+`
+
+func buildPlugin(t *testing.T, id, src string) {
+	dir := "/opt/plugins"
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	p := filepath.Join(t.TempDir(), "p.go")
+	if err := os.WriteFile(p, []byte(src), 0644); err != nil {
+		t.Fatalf("write plugin: %v", err)
+	}
 	out := filepath.Join(dir, id+".so")
-	cmd := exec.Command("go", "build", "-buildmode=plugin", "-o", out, src)
+	cmd := exec.Command("go", "build", "-buildmode=plugin", "-o", out, p)
 	if outb, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("plugin build: %v\n%s", err, outb)
 	}
@@ -97,15 +115,15 @@ func newEvent(key string, size int64) events.S3Event {
 
 func TestHandler(t *testing.T) {
 	log = zap.NewNop().Sugar()
-	buildPlugin(t, "csv_pipe")
+	buildPlugin(t, "csv_pipe", pluginSrc)
 
 	t.Run("small", func(t *testing.T) {
-               if err := os.Setenv("PARSER_ID", "csv_pipe"); err != nil {
-                       t.Fatalf("setenv: %v", err)
-               }
-               if err := os.Setenv("PROFILE_JSON", `{"required":["header1","header2"]}`); err != nil {
-                       t.Fatalf("setenv: %v", err)
-               }
+		if err := os.Setenv("PARSER_ID", "csv_pipe"); err != nil {
+			t.Fatalf("setenv: %v", err)
+		}
+		if err := os.Setenv("PROFILE_JSON", `{"required":["header1","header2"]}`); err != nil {
+			t.Fatalf("setenv: %v", err)
+		}
 		f := &fakeS3{objects: map[string][]byte{"f.qns": []byte("header1|header2\n v1 | v2 ")}}
 		s3Client = f
 		out, err := handler(context.Background(), newEvent("f.qns", 10))
@@ -125,9 +143,9 @@ func TestHandler(t *testing.T) {
 		}
 		f := &fakeS3{objects: map[string][]byte{"big.qns": []byte(sb.String())}}
 		s3Client = f
-               if err := os.Setenv("PROFILE_JSON", `{"required":["header1","header2"]}`); err != nil {
-                       t.Fatalf("setenv: %v", err)
-               }
+		if err := os.Setenv("PROFILE_JSON", `{"required":["header1","header2"]}`); err != nil {
+			t.Fatalf("setenv: %v", err)
+		}
 		out, err := handler(context.Background(), newEvent("big.qns", 30000000))
 		if err != nil {
 			t.Fatalf("handler error: %v", err)
@@ -143,9 +161,9 @@ func TestHandler(t *testing.T) {
 	t.Run("missing column", func(t *testing.T) {
 		f := &fakeS3{objects: map[string][]byte{"bad.qns": []byte("header1\nval")}}
 		s3Client = f
-               if err := os.Setenv("PROFILE_JSON", `{"required":["header1","header2"]}`); err != nil {
-                       t.Fatalf("setenv: %v", err)
-               }
+		if err := os.Setenv("PROFILE_JSON", `{"required":["header1","header2"]}`); err != nil {
+			t.Fatalf("setenv: %v", err)
+		}
 		if _, err := handler(context.Background(), newEvent("bad.qns", 10)); err == nil {
 			t.Fatal("expected error")
 		}
@@ -154,9 +172,9 @@ func TestHandler(t *testing.T) {
 	t.Run("malformed", func(t *testing.T) {
 		f := &fakeS3{objects: map[string][]byte{"m.qns": []byte("header1|header2\nval1")}}
 		s3Client = f
-               if err := os.Setenv("PROFILE_JSON", `{"required":[]}`); err != nil {
-                       t.Fatalf("setenv: %v", err)
-               }
+		if err := os.Setenv("PROFILE_JSON", `{"required":[]}`); err != nil {
+			t.Fatalf("setenv: %v", err)
+		}
 		if _, err := handler(context.Background(), newEvent("m.qns", 10)); err == nil {
 			t.Fatal("expected error")
 		}
@@ -166,10 +184,122 @@ func TestHandler(t *testing.T) {
 func TestRun(t *testing.T) {
 	called := false
 	lambdaStart = func(i interface{}) { called = true }
+	loadConfig = func(ctx context.Context, optFns ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{}, nil
+	}
 	if err := run(); err != nil {
 		t.Fatalf("run error: %v", err)
 	}
 	if !called {
 		t.Fatal("start not called")
 	}
+}
+
+func TestRunError(t *testing.T) {
+	lambdaStart = func(i interface{}) {}
+	loadConfig = func(ctx context.Context, optFns ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{}, fmt.Errorf("cfg")
+	}
+	if err := run(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetParserID(t *testing.T) {
+	t.Setenv("PARSER_ID", "")
+	if got := getParserID(); got != "csv_pipe" {
+		t.Fatalf("default id wrong: %s", got)
+	}
+}
+
+func TestLoadParserError(t *testing.T) {
+	if _, err := loadParser("nope"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLoadParserBadSymbol(t *testing.T) {
+	buildPlugin(t, "bad", badPluginSrc)
+	if _, err := loadParser("bad"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLoadParserLookup(t *testing.T) {
+	buildPlugin(t, "nosym", noSymPluginSrc)
+	if _, err := loadParser("nosym"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLoadProfileError(t *testing.T) {
+	t.Setenv("PROFILE_JSON", "bad")
+	if _, err := loadProfile(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLoadProfileDefault(t *testing.T) {
+	t.Setenv("PROFILE_JSON", "")
+	p, err := loadProfile()
+	if err != nil || len(p.Required) != 0 {
+		t.Fatalf("unexpected: %+v %v", p, err)
+	}
+}
+
+func TestValidateHeaderNoRows(t *testing.T) {
+	if err := validateHeader(nil, []string{"a"}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFilterRows(t *testing.T) {
+	rows := []map[string]string{{"a": "1", "b": ""}, {"a": "2", "b": "x"}}
+	out, bad := filterRows(rows, []string{"a", "b"})
+	if len(out) != 1 || bad != 1 {
+		t.Fatalf("unexpected: %v %d", out, bad)
+	}
+}
+
+func TestHandlerErrorPaths(t *testing.T) {
+	log = zap.NewNop().Sugar()
+	buildPlugin(t, "csv_pipe", pluginSrc)
+	t.Setenv("PARSER_ID", "csv_pipe")
+
+	t.Run("get object", func(t *testing.T) {
+		s3Client = &fakeS3{getErr: fmt.Errorf("boom")}
+		if _, err := handler(context.Background(), newEvent("x", 1)); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("load parser", func(t *testing.T) {
+		s3Client = &fakeS3{objects: map[string][]byte{"f.qns": []byte("x")}}
+		t.Setenv("PARSER_ID", "missing")
+		if _, err := handler(context.Background(), newEvent("f.qns", 1)); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("profile", func(t *testing.T) {
+		s3Client = &fakeS3{objects: map[string][]byte{"f.qns": []byte("header1|header2")}}
+		t.Setenv("PARSER_ID", "csv_pipe")
+		t.Setenv("PROFILE_JSON", "bad")
+		if _, err := handler(context.Background(), newEvent("f.qns", 1)); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("put error", func(t *testing.T) {
+		var sb strings.Builder
+		sb.WriteString("header1|header2\n")
+		for i := 0; i < 1500; i++ {
+			sb.WriteString("a|b\n")
+		}
+		s3Client = &fakeS3{objects: map[string][]byte{"big.qns": []byte(sb.String())}, putErr: fmt.Errorf("p")}
+		t.Setenv("PROFILE_JSON", `{"required":["header1","header2"]}`)
+		if _, err := handler(context.Background(), newEvent("big.qns", 30000000)); err == nil {
+			t.Fatal("expected error")
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- implement ParseFile Lambda with plugin support and chunking
- document new lambda behavior
- add unit tests covering small and large files

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875daf24cfc83288321993673746dc8