### PR TITLE
Add Token Broker Lambda

### DIFF
--- a/cmd/tokenbroker/README.md
+++ b/cmd/tokenbroker/README.md
@@ -1,0 +1,39 @@
+# Token Broker Lambda
+
+This Lambda exposes `GET /sf/token` via API Gateway and brokers Salesforce access
+tokens. Tokens are cached in memory for five minutes and persisted in DynamoDB
+`SfAuthToken` items (`PK=appId#env`). A conditional update with the
+`refreshing` flag ensures only one instance refreshes the token at a time. The
+function publishes `TokenRefreshCount` and `BrokerLatencyMs` metrics to
+CloudWatch and uses zap for structured logs.
+
+## Environment variables
+- `APP_ID` – application identifier used in Dynamo primary key
+- `ENV` – environment name (dev, prod ...)
+- `SF_TOKEN_URL` – Salesforce OAuth token endpoint
+- `SF_CLIENT_ID` – OAuth client id
+- `SF_CLIENT_SECRET` – OAuth client secret
+- `SF_USERNAME` – username
+- `SF_PASSWORD` – password
+- `AUTH_TABLE` – DynamoDB table name (default `SfAuthToken`)
+
+## Sequence diagram
+```mermaid
+sequenceDiagram
+  participant Client
+  participant API
+  participant Lambda
+  participant Dynamo
+  participant Salesforce
+  Client->>API: GET /sf/token
+  API->>Lambda: invoke
+  alt cached
+    Lambda-->>API: return token
+  else refresh
+    Lambda->>Dynamo: conditional lock
+    Lambda->>Salesforce: request token
+    Salesforce-->>Lambda: access token
+    Lambda->>Dynamo: store token & unlock
+    Lambda-->>API: return token
+  end
+```

--- a/cmd/tokenbroker/broker.go
+++ b/cmd/tokenbroker/broker.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"go.uber.org/zap"
+)
+
+type tokenStore interface {
+	Get(ctx context.Context) (token string, exp time.Time, refreshing bool, err error)
+	TryLock(ctx context.Context) (bool, error)
+	Save(ctx context.Context, token string, exp time.Time) error
+	Unlock(ctx context.Context) error
+}
+
+// Broker implements token retrieval logic.
+type metricsClient interface {
+	PutMetricData(ctx context.Context, in *cloudwatch.PutMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.PutMetricDataOutput, error)
+}
+
+type Broker struct {
+	store      tokenStore
+	cw         metricsClient
+	httpClient *http.Client
+	sfURL      string
+	creds      map[string]string
+	log        *zap.SugaredLogger
+	mu         sync.Mutex
+	token      string
+	expiry     time.Time
+}
+
+const (
+	cacheTTL = 5 * time.Minute
+	graceTTL = 15 * time.Minute
+)
+
+func (b *Broker) getToken(ctx context.Context) (string, error) {
+	b.mu.Lock()
+	if b.token != "" && time.Now().Before(b.expiry) {
+		tok := b.token
+		b.mu.Unlock()
+		return tok, nil
+	}
+	b.mu.Unlock()
+
+	tok, exp, refreshing, err := b.store.Get(ctx)
+	if err != nil {
+		b.log.Warnw("dynamo get", "error", err)
+		b.mu.Lock()
+		if b.token != "" && time.Now().Before(b.expiry.Add(graceTTL-cacheTTL)) {
+			tok := b.token
+			b.mu.Unlock()
+			return tok, nil
+		}
+		b.mu.Unlock()
+		return "", err
+	}
+	if tok != "" && time.Now().Before(exp) && !refreshing {
+		b.mu.Lock()
+		b.token = tok
+		b.expiry = exp
+		b.mu.Unlock()
+		return tok, nil
+	}
+
+	locked, err := b.store.TryLock(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !locked {
+		// Wait for other refresher
+		for i := 0; i < 10; i++ {
+			time.Sleep(50 * time.Millisecond)
+			tok, exp, refreshing, err = b.store.Get(ctx)
+			if err == nil && tok != "" && time.Now().Before(exp) && !refreshing {
+				b.mu.Lock()
+				b.token = tok
+				b.expiry = exp
+				b.mu.Unlock()
+				return tok, nil
+			}
+		}
+		return "", fmt.Errorf("timeout waiting for refresh")
+	}
+
+	token, err := b.fetchToken(ctx)
+	if err != nil {
+		b.store.Unlock(ctx)
+		return "", err
+	}
+	expTime := time.Now().Add(cacheTTL)
+	if err := b.store.Save(ctx, token, expTime); err != nil {
+		b.log.Warnw("dynamo save", "error", err)
+	}
+	b.mu.Lock()
+	b.token = token
+	b.expiry = expTime
+	b.mu.Unlock()
+	b.cw.PutMetricData(ctx, &cloudwatch.PutMetricDataInput{
+		Namespace: aws.String("TokenBroker"),
+		MetricData: []cwtypes.MetricDatum{
+			{
+				MetricName: aws.String("TokenRefreshCount"),
+				Value:      aws.Float64(1),
+			},
+		},
+	})
+	return token, nil
+}
+
+func (b *Broker) fetchToken(ctx context.Context) (string, error) {
+	form := make(urlValues)
+	for k, v := range b.creds {
+		form[k] = v
+	}
+	// 2 attempts (handle 401 rotation)
+	for i := 0; i < 2; i++ {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, b.sfURL, strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := b.httpClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		if resp.StatusCode == 401 {
+			if rot, ok := b.creds["rotate"]; ok && rot == "true" {
+				// already rotated once
+				return "", fmt.Errorf("unauthorized")
+			}
+			b.creds["rotate"] = "true"
+			continue
+		}
+		if resp.StatusCode >= 300 {
+			return "", fmt.Errorf("salesforce status %s", resp.Status)
+		}
+		var out struct {
+			AccessToken string `json:"access_token"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			return "", err
+		}
+		resp.Body.Close()
+		return out.AccessToken, nil
+	}
+	return "", fmt.Errorf("unauthorized")
+}
+
+type urlValues map[string]string
+
+func (v urlValues) Encode() string {
+	var buf strings.Builder
+	first := true
+	for k, val := range v {
+		if k == "rotate" {
+			continue
+		}
+		if !first {
+			buf.WriteByte('&')
+		}
+		first = false
+		buf.WriteString(url.QueryEscape(k))
+		buf.WriteByte('=')
+		buf.WriteString(url.QueryEscape(val))
+	}
+	return buf.String()
+}
+
+func (b *Broker) handler(ctx context.Context, evt events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	start := time.Now()
+	tok, err := b.getToken(ctx)
+	latency := time.Since(start).Milliseconds()
+	_, _ = b.cw.PutMetricData(ctx, &cloudwatch.PutMetricDataInput{
+		Namespace: aws.String("TokenBroker"),
+		MetricData: []cwtypes.MetricDatum{
+			{
+				MetricName: aws.String("BrokerLatencyMs"),
+				Value:      aws.Float64(float64(latency)),
+			},
+		},
+	})
+	if err != nil {
+		b.log.Errorw("get token", "error", err)
+		return events.APIGatewayV2HTTPResponse{StatusCode: 500}, nil
+	}
+	body, _ := json.Marshal(map[string]string{"token": tok})
+	return events.APIGatewayV2HTTPResponse{StatusCode: 200, Body: string(body), Headers: map[string]string{"Content-Type": "application/json"}}, nil
+}

--- a/cmd/tokenbroker/dynamo_store.go
+++ b/cmd/tokenbroker/dynamo_store.go
@@ -1,0 +1,110 @@
+//go:build lambda
+
+package main
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+type dynamoAPI interface {
+	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+}
+
+type dynamoStore struct {
+	table string
+	pk    string
+	db    dynamoAPI
+}
+
+func (d *dynamoStore) Get(ctx context.Context) (string, time.Time, bool, error) {
+	out, err := d.db.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: &d.table,
+		Key: map[string]dbtypes.AttributeValue{
+			"PK": &dbtypes.AttributeValueMemberS{Value: d.pk},
+		},
+	})
+	if err != nil {
+		return "", time.Time{}, false, err
+	}
+	if out.Item == nil {
+		return "", time.Time{}, false, nil
+	}
+	tokAttr, ok := out.Item["Token"].(*dbtypes.AttributeValueMemberS)
+	if !ok {
+		return "", time.Time{}, false, nil
+	}
+	expAttr, ok := out.Item["ExpiresAt"].(*dbtypes.AttributeValueMemberN)
+	var exp time.Time
+	if ok {
+		if v, err := strconv.ParseInt(expAttr.Value, 10, 64); err == nil {
+			exp = time.Unix(v, 0)
+		}
+	}
+	refAttr, _ := out.Item["Refreshing"].(*dbtypes.AttributeValueMemberBOOL)
+	refreshing := false
+	if refAttr != nil {
+		refreshing = refAttr.Value
+	}
+	return tokAttr.Value, exp, refreshing, nil
+}
+
+func (d *dynamoStore) TryLock(ctx context.Context) (bool, error) {
+	_, err := d.db.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: &d.table,
+		Key: map[string]dbtypes.AttributeValue{
+			"PK": &dbtypes.AttributeValueMemberS{Value: d.pk},
+		},
+		UpdateExpression:    aws.String("SET Refreshing = :t"),
+		ConditionExpression: aws.String("attribute_not_exists(Refreshing) OR Refreshing = :f"),
+		ExpressionAttributeValues: map[string]dbtypes.AttributeValue{
+			":t": &dbtypes.AttributeValueMemberBOOL{Value: true},
+			":f": &dbtypes.AttributeValueMemberBOOL{Value: false},
+		},
+	})
+	if err != nil {
+		var ccfe *dbtypes.ConditionalCheckFailedException
+		if errors.As(err, &ccfe) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (d *dynamoStore) Save(ctx context.Context, token string, exp time.Time) error {
+	_, err := d.db.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: &d.table,
+		Key: map[string]dbtypes.AttributeValue{
+			"PK": &dbtypes.AttributeValueMemberS{Value: d.pk},
+		},
+		UpdateExpression: aws.String("SET Token = :tok, ExpiresAt = :exp, Refreshing = :f"),
+		ExpressionAttributeValues: map[string]dbtypes.AttributeValue{
+			":tok": &dbtypes.AttributeValueMemberS{Value: token},
+			":exp": &dbtypes.AttributeValueMemberN{Value: strconv.FormatInt(exp.Unix(), 10)},
+			":f":   &dbtypes.AttributeValueMemberBOOL{Value: false},
+		},
+	})
+	return err
+}
+
+func (d *dynamoStore) Unlock(ctx context.Context) error {
+	_, err := d.db.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: &d.table,
+		Key: map[string]dbtypes.AttributeValue{
+			"PK": &dbtypes.AttributeValueMemberS{Value: d.pk},
+		},
+		UpdateExpression: aws.String("SET Refreshing = :f"),
+		ExpressionAttributeValues: map[string]dbtypes.AttributeValue{
+			":f": &dbtypes.AttributeValueMemberBOOL{Value: false},
+		},
+	})
+	return err
+}

--- a/cmd/tokenbroker/lambda_main.go
+++ b/cmd/tokenbroker/lambda_main.go
@@ -1,0 +1,45 @@
+//go:build lambda
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"go.uber.org/zap"
+)
+
+func main() {
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	logger, _ := zap.NewProduction()
+	log := logger.Sugar()
+	table := os.Getenv("AUTH_TABLE")
+	if table == "" {
+		table = "SfAuthToken"
+	}
+	pk := os.Getenv("APP_ID") + "#" + os.Getenv("ENV")
+	store := &dynamoStore{table: table, pk: pk, db: dynamodb.NewFromConfig(cfg)}
+	broker := &Broker{
+		store:      store,
+		cw:         cloudwatch.NewFromConfig(cfg),
+		httpClient: http.DefaultClient,
+		sfURL:      os.Getenv("SF_TOKEN_URL"),
+		creds: map[string]string{
+			"client_id":     os.Getenv("SF_CLIENT_ID"),
+			"client_secret": os.Getenv("SF_CLIENT_SECRET"),
+			"username":      os.Getenv("SF_USERNAME"),
+			"password":      os.Getenv("SF_PASSWORD"),
+			"grant_type":    "password",
+		},
+		log: log,
+	}
+	lambda.Start(broker.handler)
+}

--- a/cmd/tokenbroker/main_test.go
+++ b/cmd/tokenbroker/main_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"go.uber.org/zap"
+	"strings"
+)
+
+type fakeStore struct {
+	mu         sync.Mutex
+	token      string
+	exp        time.Time
+	refreshing bool
+	fail       bool
+	lockFail   bool
+	lockErr    bool
+	saveErr    bool
+}
+
+func (f *fakeStore) Get(ctx context.Context) (string, time.Time, bool, error) {
+	if f.fail {
+		return "", time.Time{}, false, fmt.Errorf("dynamo down")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.token, f.exp, f.refreshing, nil
+}
+
+func (f *fakeStore) TryLock(ctx context.Context) (bool, error) {
+	if f.fail {
+		return false, fmt.Errorf("dynamo down")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.lockErr {
+		return false, fmt.Errorf("lock err")
+	}
+	if f.refreshing || f.lockFail {
+		return false, nil
+	}
+	f.refreshing = true
+	return true, nil
+}
+
+func (f *fakeStore) Save(ctx context.Context, token string, exp time.Time) error {
+	if f.fail {
+		return fmt.Errorf("dynamo down")
+	}
+	if f.saveErr {
+		return fmt.Errorf("save error")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.token = token
+	f.exp = exp
+	f.refreshing = false
+	return nil
+}
+
+func (f *fakeStore) Unlock(ctx context.Context) error {
+	if f.fail {
+		return fmt.Errorf("dynamo down")
+	}
+	f.mu.Lock()
+	f.refreshing = false
+	f.mu.Unlock()
+	return nil
+}
+
+type fakeCW struct {
+	mu  sync.Mutex
+	cnt int
+}
+
+func (f *fakeCW) PutMetricData(ctx context.Context, in *cloudwatch.PutMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.PutMetricDataOutput, error) {
+	f.mu.Lock()
+	f.cnt += len(in.MetricData)
+	f.mu.Unlock()
+	return &cloudwatch.PutMetricDataOutput{}, nil
+}
+
+func TestCachedToken(t *testing.T) {
+	store := &fakeStore{}
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		fmt.Fprint(w, `{"access_token":"t1"}`)
+	}))
+	defer srv.Close()
+	b := &Broker{
+		store:      store,
+		cw:         &fakeCW{},
+		httpClient: srv.Client(),
+		sfURL:      srv.URL,
+		creds:      map[string]string{"grant_type": "password"},
+		log:        zap.NewNop().Sugar(),
+	}
+	resp, err := b.handler(context.Background(), events.APIGatewayV2HTTPRequest{})
+	if err != nil || resp.StatusCode != 200 {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+	resp, err = b.handler(context.Background(), events.APIGatewayV2HTTPRequest{})
+	if err != nil || resp.StatusCode != 200 {
+		t.Fatalf("second call error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("token was not cached")
+	}
+}
+
+func TestConcurrentLock(t *testing.T) {
+	store := &fakeStore{}
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		fmt.Fprint(w, `{"access_token":"t2"}`)
+	}))
+	defer srv.Close()
+	b := &Broker{store: store, cw: &fakeCW{}, httpClient: srv.Client(), sfURL: srv.URL, creds: map[string]string{"grant_type": "password"}, log: zap.NewNop().Sugar()}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { b.getToken(context.Background()); wg.Done() }()
+	go func() { b.getToken(context.Background()); wg.Done() }()
+	wg.Wait()
+	if calls != 1 {
+		t.Fatalf("expected 1 refresh, got %d", calls)
+	}
+}
+
+func TestDynamoUnavailableGrace(t *testing.T) {
+	store := &fakeStore{fail: true}
+	b := &Broker{store: store, cw: &fakeCW{}, httpClient: http.DefaultClient, sfURL: "", creds: map[string]string{}, log: zap.NewNop().Sugar()}
+	b.token = "cached"
+	b.expiry = time.Now().Add(-6 * time.Minute)
+	tok, err := b.getToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "cached" {
+		t.Fatalf("expected cached token, got %s", tok)
+	}
+}
+
+func TestSalesforce401Rotation(t *testing.T) {
+	store := &fakeStore{}
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(401)
+			return
+		}
+		fmt.Fprint(w, `{"access_token":"new"}`)
+	}))
+	defer srv.Close()
+	b := &Broker{store: store, cw: &fakeCW{}, httpClient: srv.Client(), sfURL: srv.URL, creds: map[string]string{"grant_type": "password"}, log: zap.NewNop().Sugar()}
+	tok, err := b.getToken(context.Background())
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if tok != "new" || calls != 2 || b.creds["rotate"] != "true" {
+		t.Fatalf("rotation not triggered")
+	}
+}
+
+func TestLockTimeout(t *testing.T) {
+	store := &fakeStore{lockFail: true}
+	b := &Broker{store: store, cw: &fakeCW{}, httpClient: http.DefaultClient, sfURL: "", creds: map[string]string{"grant_type": "password"}, log: zap.NewNop().Sugar()}
+	_, err := b.getToken(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "timeout") {
+		t.Fatalf("expected timeout")
+	}
+}
+
+func TestFetchTokenError(t *testing.T) {
+	store := &fakeStore{}
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(401)
+	}))
+	defer srv.Close()
+	b := &Broker{store: store, cw: &fakeCW{}, httpClient: srv.Client(), sfURL: srv.URL, creds: map[string]string{"grant_type": "password"}, log: zap.NewNop().Sugar()}
+	_, err := b.getToken(context.Background())
+	if err == nil || calls != 2 {
+		t.Fatalf("expected error and two calls")
+	}
+}


### PR DESCRIPTION
## Summary
- add new Token Broker Lambda with Dynamo locking
- document environment variables and flow
- cover broker logic with unit tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6875db5f95588328b5d2bcdc792268c9