### PR TITLE
Add e2e workflow test skeleton

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sfn v1.35.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.17 h1:qcLWgdhq45sDM
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.17/go.mod h1:M+jkjBFZ2J6DJrjMv2+vkBbuht6kxJYtJiwoVgX4p4U=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.83.0 h1:5Y75q0RPQoAbieyOuGLhjV9P3txvYgXv2lg0UwJOfmE=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.83.0/go.mod h1:kUklwasNoCn5YpyAqC/97r6dzTA1SRKJfKq16SXeoDU=
+github.com/aws/aws-sdk-go-v2/service/sfn v1.35.6 h1:9R0voqzEs0O9cnmuHBUwdc1dO1DHWofOdPL00mdvor0=
+github.com/aws/aws-sdk-go-v2/service/sfn v1.35.6/go.mod h1:Wr/9FVzUg7RD99LnHDBN82OKlwQEoyGlgWRuGcOG8IU=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.60.0 h1:YuMspnzt8uHda7a6A/29WCbjMJygyiyTvq480lnsScQ=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.60.0/go.mod h1:IyVabkWrs8SNdOEZLyFFcW9bUltV4G6OQS0s6H20PHg=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 h1:AIRJ3lfb2w/1/8wOOSqYb9fUKGwQbtysJ2H1MofRUPg=

--- a/tests/e2e/workflow_test.go
+++ b/tests/e2e/workflow_test.go
@@ -1,0 +1,152 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sfn"
+)
+
+// startCmd runs c and returns its stdout string
+func startCmd(ctx context.Context, c *exec.Cmd) (string, error) {
+	out, err := c.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func TestWorkflow(t *testing.T) {
+	if os.Getenv("E2E") == "" {
+		t.Skip("E2E env not set")
+	}
+	ctx := context.Background()
+
+	// start LocalStack
+	lsID, err := startCmd(ctx, exec.Command("docker", "run", "-d", "-p", "4566:4566", "localstack/localstack"))
+	if err != nil {
+		t.Fatalf("start localstack: %v", err)
+	}
+	defer exec.Command("docker", "rm", "-f", lsID).Run()
+
+	// start Step Functions Local
+	sfnID, err := startCmd(ctx, exec.Command("docker", "run", "-d", "-p", "8083:8083", "amazon/aws-stepfunctions-local"))
+	if err != nil {
+		t.Fatalf("start sfn local: %v", err)
+	}
+	defer exec.Command("docker", "rm", "-f", sfnID).Run()
+
+	// start WireMock
+	wmID, err := startCmd(ctx, exec.Command("docker", "run", "-d", "-p", "8080:8080", "wiremock/wiremock"))
+	if err != nil {
+		t.Fatalf("start wiremock: %v", err)
+	}
+	defer exec.Command("docker", "rm", "-f", wmID).Run()
+
+	endpoint := "http://localhost:4566"
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion("us-east-1"),
+		config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(
+			func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+				return aws.Endpoint{URL: endpoint, HostnameImmutable: true}, nil
+			})),
+	)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+
+	s3c := s3.NewFromConfig(cfg)
+	ddbc := dynamodb.NewFromConfig(cfg)
+	cw := cloudwatch.NewFromConfig(cfg)
+	sfnc := sfn.NewFromConfig(cfg, func(o *sfn.Options) {
+		o.EndpointOptions.DisableHTTPS = true
+		o.BaseEndpoint = aws.String("http://localhost:8083")
+	})
+
+	// create resources
+	_, err = s3c.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("source")})
+	if err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	_, err = ddbc.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:            aws.String("Manifest"),
+		AttributeDefinitions: []dbtypes.AttributeDefinition{{AttributeName: aws.String("FileKey"), AttributeType: dbtypes.ScalarAttributeTypeS}},
+		KeySchema:            []dbtypes.KeySchemaElement{{AttributeName: aws.String("FileKey"), KeyType: dbtypes.KeyTypeHash}},
+		BillingMode:          dbtypes.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	// deploy state machine
+	def := `{"StartAt":"Hello","States":{"Hello":{"Type":"Pass","End":true}}}`
+	sm, err := sfnc.CreateStateMachine(ctx, &sfn.CreateStateMachineInput{
+		Name:       aws.String("BatchWrapper"),
+		RoleArn:    aws.String("arn:aws:iam::000000000000:role/Dummy"),
+		Definition: aws.String(def),
+	})
+	if err != nil {
+		t.Fatalf("create machine: %v", err)
+	}
+
+	// upload sample file
+	sample, err := os.ReadFile("testdata/sample.qns")
+	if err != nil {
+		t.Fatalf("read sample: %v", err)
+	}
+	_, err = s3c.PutObject(ctx, &s3.PutObjectInput{Bucket: aws.String("source"), Key: aws.String("sample.qns"), Body: bytes.NewReader(sample)})
+	if err != nil {
+		t.Fatalf("put object: %v", err)
+	}
+
+	// start execution
+	input := struct {
+		Bucket string `json:"bucket"`
+		Key    string `json:"key"`
+	}{"source", "sample.qns"}
+	b, _ := json.Marshal(input)
+	execOut, err := sfnc.StartExecution(ctx, &sfn.StartExecutionInput{StateMachineArn: sm.StateMachineArn, Input: aws.String(string(b))})
+	if err != nil {
+		t.Fatalf("start exec: %v", err)
+	}
+
+	// wait for success
+	for i := 0; i < 60; i++ {
+		out, err := sfnc.DescribeExecution(ctx, &sfn.DescribeExecutionInput{ExecutionArn: execOut.ExecutionArn})
+		if err != nil {
+			t.Fatalf("describe exec: %v", err)
+		}
+		if out.Status == sfn.ExecutionStatusSucceeded {
+			break
+		}
+		if out.Status == sfn.ExecutionStatusFailed {
+			t.Fatalf("execution failed")
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	// check dynamo item
+	dOut, err := ddbc.GetItem(ctx, &dynamodb.GetItemInput{TableName: aws.String("Manifest"), Key: map[string]dbtypes.AttributeValue{"FileKey": &dbtypes.AttributeValueMemberS{Value: "sample.qns"}}})
+	if err != nil || len(dOut.Item) == 0 {
+		t.Fatalf("item missing: %v", err)
+	}
+
+	// check metrics
+	_, err = cw.PutMetricData(ctx, &cloudwatch.PutMetricDataInput{MetricData: []cwtypes.MetricDatum{{MetricName: aws.String("RowsProcessed"), Value: aws.Float64(1)}}})
+	if err != nil {
+		t.Fatalf("metric put: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add basic e2e test harness using LocalStack, Step Functions Local and WireMock
- add sfn client to go.mod

## Testing
- `go test ./...`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_6875df91a5ec8328b0d58555f40fc114