### PR TITLE
Add multi-stage CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,50 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v4
-      with:
-        go-version: '1.22'
-    - name: Install golangci-lint
-      run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
-    - run: go test ./...
-    - run: golangci-lint run
-    - run: sam validate --region us-east-1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+      - uses: aws-actions/setup-sam@v2
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+            | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+      - name: Lint
+        run: golangci-lint run
+      - name: Unit tests
+        run: go test -coverprofile=coverage.out ./...
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.out
+      - name: Validate profiles
+        run: |
+          for f in sample-profiles/*.json; do
+            jq empty "$f"
+          done
+      - name: SAM validate
+        run: sam validate --region us-east-1
+      - name: SAM build
+        run: sam build
+      - name: Dev deploy
+        if: github.ref == 'refs/heads/main'
+        run: sam deploy --config-env dev --no-confirm-changeset --no-fail-on-empty-changeset
+      - name: Smoke invoke
+        if: github.ref == 'refs/heads/main'
+        run: sam local invoke GuardDuplicate --event testdata/s3_event.json
+      - name: Prod deploy
+        if: startsWith(github.ref, 'refs/tags/')
+        run: sam deploy --config-env prod --no-confirm-changeset --no-fail-on-empty-changeset


### PR DESCRIPTION
## Summary
- replace CI job with multi-stage workflow
- add linting, testing, profile validation, SAM build, dev deploy, smoke invoke
- upload test coverage to Codecov
- deploy to prod on tagged releases

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6875df8525708328a9880d3de9d48ac3