### PR TITLE
Add step function auditing

### DIFF
--- a/audit/Project-Status-Report.md
+++ b/audit/Project-Status-Report.md
@@ -1,0 +1,5 @@
+## Step-Function Audit
+_No Step Functions found_
+
+
+Missing ASL files: campaign, qns

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/your-org/file-processor-sample/internal/validator"
+)
+
+func main() {
+	roots := []string{"sfn", "infra", "cmd"}
+	aslFiles, _ := validator.DiscoverASL(roots)
+
+	// check profiles for expected ASL
+	profiles, _ := filepath.Glob(filepath.Join("sample-profiles", "*.json"))
+	taskID := 1
+	var missing []string
+	for _, p := range profiles {
+		base := strings.TrimSuffix(filepath.Base(p), filepath.Ext(p))
+		expected := filepath.Join("build", base+".asl.json")
+		if _, err := os.Stat(expected); err != nil {
+			task := filepath.Join("tasks", fmt.Sprintf("TASK-SFN-%03d_%s.md", taskID, base))
+			createTask(task, expected, []error{fmt.Errorf("missing ASL for profile %s", base)})
+			taskID++
+			missing = append(missing, base)
+		}
+	}
+
+	reportDir := filepath.Join("audit")
+	os.MkdirAll(reportDir, 0o755)
+	reportPath := filepath.Join(reportDir, "Project-Status-Report.md")
+
+	tasksDir := "tasks"
+	os.MkdirAll(tasksDir, 0o755)
+
+	var table string
+	var hasErrors bool
+	for _, f := range aslFiles {
+		errs := validator.ValidateASL(f)
+		data, _ := os.ReadFile(f)
+		errs = append(errs, validator.PolicyViolations(data)...)
+		if len(errs) > 0 {
+			hasErrors = true
+			slug := filepath.Base(f)
+			slug = slug[:len(slug)-len(filepath.Ext(slug))]
+			taskPath := filepath.Join(tasksDir, fmt.Sprintf("TASK-SFN-%03d_%s.md", taskID, slug))
+			taskID++
+			createTask(taskPath, f, errs)
+			table += fmt.Sprintf("| %s | ❌ |\n", f)
+		} else {
+			table += fmt.Sprintf("| %s | ✅ |\n", f)
+		}
+	}
+	if table == "" {
+		table = "_No Step Functions found_\n"
+	} else {
+		table = "| File | Status |\n|------|--------|\n" + table
+	}
+	if len(missing) > 0 {
+		table += "\n\nMissing ASL files: " + strings.Join(missing, ", ")
+	}
+
+	badge := ""
+	if !hasErrors && len(aslFiles) > 0 {
+		badge = "\n\nState Machine Integrity ✅"
+	}
+
+	content := fmt.Sprintf("## Step-Function Audit\n%s%s\n", table, badge)
+
+	os.WriteFile(reportPath, []byte(content), 0o644)
+}
+
+func createTask(path, file string, errs []error) {
+	var b string
+	b += fmt.Sprintf("# Step Function issue for %s\n\n", file)
+	b += "## Problems\n"
+	for _, e := range errs {
+		b += fmt.Sprintf("- %v\n", e)
+	}
+	b += "\n## Acceptance Criteria\n- Updated definition passes validation and policy checks\n"
+	b += "\n## Suggested Steps\n- Review state machine structure\n- Add required fields or transitions\n"
+	b += "\nEffort: M\nOwner: TBD\n"
+	os.WriteFile(path, []byte(b), 0o644)
+}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect
 	github.com/aws/smithy-go v1.22.4 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5O
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/internal/validator/aws-states-language.json
+++ b/internal/validator/aws-states-language.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["StartAt", "States"],
+  "properties": {
+    "Comment": {"type": "string"},
+    "StartAt": {"type": "string"},
+    "States": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["Type"],
+        "properties": {
+          "Type": {"type": "string", "enum": ["Task","Pass","Choice","Wait","Succeed","Fail","Parallel","Map"]},
+          "Next": {"type": "string"},
+          "End": {"type": "boolean"}
+        }
+      }
+    }
+  }
+}

--- a/internal/validator/policy.go
+++ b/internal/validator/policy.go
@@ -1,0 +1,71 @@
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+)
+
+// PolicyViolations runs policy checks on the state machine definition bytes.
+func PolicyViolations(data []byte) []error {
+	var def struct {
+		Comment string                    `json:"Comment"`
+		States  map[string]map[string]any `json:"States"`
+	}
+	if err := json.Unmarshal(data, &def); err != nil {
+		return []error{err}
+	}
+	var errs []error
+	// top-level comment presence
+	if def.Comment == "" {
+		errs = append(errs, fmt.Errorf("missing Comment"))
+	}
+	for name, state := range def.States {
+		t, _ := state["Type"].(string)
+		// TimeoutSeconds check for key states
+		if name == "GuardDuplicate" || name == "ParseFile" || name == "ArchiveMetrics" {
+			if _, ok := state["TimeoutSeconds"]; !ok {
+				errs = append(errs, fmt.Errorf("%s missing TimeoutSeconds", name))
+			}
+		}
+		// Map MaxConcurrency
+		if t == "Map" {
+			if _, ok := state["MaxConcurrency"]; !ok {
+				errs = append(errs, fmt.Errorf("%s missing MaxConcurrency", name))
+			}
+		}
+		// Lambda Retry/Catch
+		if t == "Task" {
+			if res, ok := state["Resource"].(string); ok && strings.Contains(res, "lambda") {
+				if _, hasRetry := state["Retry"]; !hasRetry {
+					if _, hasCatch := state["Catch"]; !hasCatch {
+						errs = append(errs, fmt.Errorf("%s invokes Lambda without Retry or Catch", name))
+					}
+				}
+			}
+		}
+		// transitions
+		if _, ok := state["End"]; !ok {
+			if _, ok := state["Next"]; !ok {
+				errs = append(errs, fmt.Errorf("%s missing Next or End", name))
+			}
+		}
+	}
+	return errs
+}
+
+// ExtractLambdas returns lambda function names referenced by the definition.
+func ExtractLambdas(data []byte) []string {
+	var def struct{ States map[string]map[string]any }
+	json.Unmarshal(data, &def)
+	var out []string
+	for _, s := range def.States {
+		if res, ok := s["Resource"].(string); ok {
+			if strings.Contains(res, "lambda") {
+				out = append(out, path.Base(res))
+			}
+		}
+	}
+	return out
+}

--- a/internal/validator/sfn.go
+++ b/internal/validator/sfn.go
@@ -1,0 +1,82 @@
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+
+	_ "embed"
+)
+
+//go:embed aws-states-language.json
+var schemaData []byte
+var schema *jsonschema.Schema
+
+func init() {
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("schema.json", strings.NewReader(string(schemaData))); err != nil {
+		panic(err)
+	}
+	var err error
+	schema, err = compiler.Compile("schema.json")
+	if err != nil {
+		panic(err)
+	}
+}
+
+// ASLFile holds info about a Step Function definition.
+type ASLFile struct {
+	Path   string
+	Errors []error
+}
+
+// DiscoverASL finds .asl.json and .asl.yaml files under the given roots.
+func DiscoverASL(roots []string) ([]string, error) {
+	var files []string
+	for _, root := range roots {
+		filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if strings.HasSuffix(path, ".asl.json") || strings.HasSuffix(path, ".asl.yaml") {
+				files = append(files, path)
+			}
+			return nil
+		})
+	}
+	return files, nil
+}
+
+// ValidateASL validates the given Step Function file.
+func ValidateASL(path string) []error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return []error{fmt.Errorf("read: %w", err)}
+	}
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		return []error{fmt.Errorf("decode: %w", err)}
+	}
+	if err := schema.Validate(v); err != nil {
+		if ve, ok := err.(*jsonschema.ValidationError); ok {
+			var errs []error
+			for _, e := range ve.Causes {
+				errs = append(errs, fmt.Errorf(e.InstanceLocation+": "+e.Message))
+			}
+			if len(errs) == 0 {
+				errs = append(errs, err)
+			}
+			return errs
+		}
+		return []error{err}
+	}
+	return nil
+}

--- a/tasks/TASK-SFN-001_campaign.md
+++ b/tasks/TASK-SFN-001_campaign.md
@@ -1,0 +1,14 @@
+# Step Function issue for build/campaign.asl.json
+
+## Problems
+- missing ASL for profile campaign
+
+## Acceptance Criteria
+- Updated definition passes validation and policy checks
+
+## Suggested Steps
+- Review state machine structure
+- Add required fields or transitions
+
+Effort: M
+Owner: TBD

--- a/tasks/TASK-SFN-002_qns.md
+++ b/tasks/TASK-SFN-002_qns.md
@@ -1,0 +1,14 @@
+# Step Function issue for build/qns.asl.json
+
+## Problems
+- missing ASL for profile qns
+
+## Acceptance Criteria
+- Updated definition passes validation and policy checks
+
+## Suggested Steps
+- Review state machine structure
+- Add required fields or transitions
+
+Effort: M
+Owner: TBD


### PR DESCRIPTION
## Summary
- add validator to check Step Function definitions
- create policy checks for step functions
- embed a schema for AWS Step Functions
- generate audit report and tasks for missing ASLs

## Testing
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/validator`

------
https://chatgpt.com/codex/tasks/task_e_6875e43c7aa883288a4e961cb23f6287