### PR TITLE
Add profile schema, samples, and README guidance

### DIFF
--- a/cmd/archive/README.md
+++ b/cmd/archive/README.md
@@ -24,3 +24,22 @@ flowchart TD
     B --> C[Update Manifest]
     C --> D[Emit Metrics]
 ```
+
+### How to Add a New Process
+1. **Author a Profile v2:** copy the sample JSON, adjust limits & mappings, then save as `/crm/file-profiles/<env>/<source>.json` in SSM.
+2. **Connect Row Step Function:** set `rowStateMachineArn` to a new or existing row-level SFN.
+3. **Deploy:** `sam deploy --guided` — core Lambdas need no changes.
+4. **Validate:** run `profile-lint` then upload a test file to `crm-incoming/<source>/dev/`.
+5. **Monitor:** dashboards show `RowsProcessed`, `RowsFailed`, alarms, and metrics.
+
+### Profile v2 Schema & Sample
+*Canonical schema:* [`schema/profile_v2.schema.json`](../../schema/profile_v2.schema.json)
+*Example profile (Flood QNS):*
+```json
+{
+  "parserId": "csv_pipe",
+  "maxBytes": 8000000,
+  "...":      "..."
+}
+```
+

--- a/cmd/guardduplicate/README.md
+++ b/cmd/guardduplicate/README.md
@@ -38,3 +38,22 @@ flowchart TD
     F --> G[PutItem Dynamo]
 ```
 ```
+
+### How to Add a New Process
+1. **Author a Profile v2:** copy the sample JSON, adjust limits & mappings, then save as `/crm/file-profiles/<env>/<source>.json` in SSM.
+2. **Connect Row Step Function:** set `rowStateMachineArn` to a new or existing row-level SFN.
+3. **Deploy:** `sam deploy --guided` — core Lambdas need no changes.
+4. **Validate:** run `profile-lint` then upload a test file to `crm-incoming/<source>/dev/`.
+5. **Monitor:** dashboards show `RowsProcessed`, `RowsFailed`, alarms, and metrics.
+
+### Profile v2 Schema & Sample
+*Canonical schema:* [`schema/profile_v2.schema.json`](../../schema/profile_v2.schema.json)
+*Example profile (Flood QNS):*
+```json
+{
+  "parserId": "csv_pipe",
+  "maxBytes": 8000000,
+  "...":      "..."
+}
+```
+

--- a/cmd/logimporterror/README.md
+++ b/cmd/logimporterror/README.md
@@ -27,3 +27,22 @@ sequenceDiagram
     B-->>L: Bearer token
     L->>SF: PATCH Import_Error__c
 ```
+
+### How to Add a New Process
+1. **Author a Profile v2:** copy the sample JSON, adjust limits & mappings, then save as `/crm/file-profiles/<env>/<source>.json` in SSM.
+2. **Connect Row Step Function:** set `rowStateMachineArn` to a new or existing row-level SFN.
+3. **Deploy:** `sam deploy --guided` — core Lambdas need no changes.
+4. **Validate:** run `profile-lint` then upload a test file to `crm-incoming/<source>/dev/`.
+5. **Monitor:** dashboards show `RowsProcessed`, `RowsFailed`, alarms, and metrics.
+
+### Profile v2 Schema & Sample
+*Canonical schema:* [`schema/profile_v2.schema.json`](../../schema/profile_v2.schema.json)
+*Example profile (Flood QNS):*
+```json
+{
+  "parserId": "csv_pipe",
+  "maxBytes": 8000000,
+  "...":      "..."
+}
+```
+

--- a/cmd/parsefile/README.md
+++ b/cmd/parsefile/README.md
@@ -29,3 +29,22 @@ sequenceDiagram
     PF-->>S3: (optional) JSONL chunks
     PF-->>SF: Rows or keys
 ```
+
+### How to Add a New Process
+1. **Author a Profile v2:** copy the sample JSON, adjust limits & mappings, then save as `/crm/file-profiles/<env>/<source>.json` in SSM.
+2. **Connect Row Step Function:** set `rowStateMachineArn` to a new or existing row-level SFN.
+3. **Deploy:** `sam deploy --guided` — core Lambdas need no changes.
+4. **Validate:** run `profile-lint` then upload a test file to `crm-incoming/<source>/dev/`.
+5. **Monitor:** dashboards show `RowsProcessed`, `RowsFailed`, alarms, and metrics.
+
+### Profile v2 Schema & Sample
+*Canonical schema:* [`schema/profile_v2.schema.json`](../../schema/profile_v2.schema.json)
+*Example profile (Flood QNS):*
+```json
+{
+  "parserId": "csv_pipe",
+  "maxBytes": 8000000,
+  "...":      "..."
+}
+```
+

--- a/cmd/tokenbroker/README.md
+++ b/cmd/tokenbroker/README.md
@@ -37,3 +37,22 @@ sequenceDiagram
     Lambda-->>API: return token
   end
 ```
+
+### How to Add a New Process
+1. **Author a Profile v2:** copy the sample JSON, adjust limits & mappings, then save as `/crm/file-profiles/<env>/<source>.json` in SSM.
+2. **Connect Row Step Function:** set `rowStateMachineArn` to a new or existing row-level SFN.
+3. **Deploy:** `sam deploy --guided` — core Lambdas need no changes.
+4. **Validate:** run `profile-lint` then upload a test file to `crm-incoming/<source>/dev/`.
+5. **Monitor:** dashboards show `RowsProcessed`, `RowsFailed`, alarms, and metrics.
+
+### Profile v2 Schema & Sample
+*Canonical schema:* [`schema/profile_v2.schema.json`](../../schema/profile_v2.schema.json)
+*Example profile (Flood QNS):*
+```json
+{
+  "parserId": "csv_pipe",
+  "maxBytes": 8000000,
+  "...":      "..."
+}
+```
+

--- a/crm/file-profiles/dev/flood_qns.json
+++ b/crm/file-profiles/dev/flood_qns.json
@@ -1,0 +1,45 @@
+{
+    "parserId": "csv_pipe",
+    "maxBytes": 8000000,
+    "maxRows": 600000,
+    "rowStateMachineArn": "arn:aws:states:us-east-1:123456789012:stateMachine:RowProcessorFlood",
+    "mapMaxConcurrency": 200,
+    "rowValidation": {
+        "required": ["MemberNumber", "QuoteNumber", "Email"],
+        "regex":    { "Email": ".+@.+" }
+    },
+    "targets": [
+        {
+            "object": "Account",
+            "externalId": "Member_Number__c",
+            "fieldMap": {
+                "MemberNumber": "Member_Number__c",
+                "FirstName":    "FirstName",
+                "LastName":     "LastName",
+                "Email":        "PersonEmail"
+            }
+        },
+        {
+            "object": "Opportunity",
+            "externalId": "Quote_Number__c",
+            "link": { "AccountId": "@{Account.id}" },
+            "fieldMap": {
+                "QuoteNumber":  "Quote_Number__c",
+                "QuoteDate":    "CloseDate",
+                "QuoteStage":   "StageName",
+                "CoverageAmt":  "Coverage_Amount__c",
+                "Premium":      "Premium__c"
+            }
+        },
+        {
+            "object": "Quote__c",
+            "externalId": "ExternalRowId__c",
+            "link": { "Opportunity__c": "@{Opportunity.id}" },
+            "fieldMap": {
+                "ExternalRowId": "ExternalRowId__c",
+                "Deductible":    "Deductible__c",
+                "ExpirationDate":"Expiration_Date__c"
+            }
+        }
+    ]
+}

--- a/crm/file-profiles/prod/flood_qns.json
+++ b/crm/file-profiles/prod/flood_qns.json
@@ -1,0 +1,45 @@
+{
+    "parserId": "csv_pipe",
+    "maxBytes": 8000000,
+    "maxRows": 600000,
+    "rowStateMachineArn": "arn:aws:states:us-east-1:123456789012:stateMachine:RowProcessorFlood",
+    "mapMaxConcurrency": 200,
+    "rowValidation": {
+        "required": ["MemberNumber", "QuoteNumber", "Email"],
+        "regex":    { "Email": ".+@.+" }
+    },
+    "targets": [
+        {
+            "object": "Account",
+            "externalId": "Member_Number__c",
+            "fieldMap": {
+                "MemberNumber": "Member_Number__c",
+                "FirstName":    "FirstName",
+                "LastName":     "LastName",
+                "Email":        "PersonEmail"
+            }
+        },
+        {
+            "object": "Opportunity",
+            "externalId": "Quote_Number__c",
+            "link": { "AccountId": "@{Account.id}" },
+            "fieldMap": {
+                "QuoteNumber":  "Quote_Number__c",
+                "QuoteDate":    "CloseDate",
+                "QuoteStage":   "StageName",
+                "CoverageAmt":  "Coverage_Amount__c",
+                "Premium":      "Premium__c"
+            }
+        },
+        {
+            "object": "Quote__c",
+            "externalId": "ExternalRowId__c",
+            "link": { "Opportunity__c": "@{Opportunity.id}" },
+            "fieldMap": {
+                "ExternalRowId": "ExternalRowId__c",
+                "Deductible":    "Deductible__c",
+                "ExpirationDate":"Expiration_Date__c"
+            }
+        }
+    ]
+}

--- a/docs/field-glossary.md
+++ b/docs/field-glossary.md
@@ -1,0 +1,20 @@
+# Profile Field Glossary
+
+| Field | Description |
+|-------|-------------|
+| `parserId` | Identifier for the plug-in parser to use (`csv_pipe`, `fixed_width`, or `xlsx_sheet`). |
+| `maxBytes` | Maximum allowed file size in bytes. |
+| `maxRows` | Maximum number of rows permitted in the file. |
+| `rowStateMachineArn` | ARN of the Step Function that processes each row. |
+| `mapMaxConcurrency` | Maximum parallelism for the Map state when invoking row processors. |
+| `rowValidation` | Rules applied to each row before processing. |
+| `rowValidation.required` | List of required field names. |
+| `rowValidation.regex` | Map of field names to regex patterns for validation. |
+| `preProcessors` | Optional list of pre-processing plug-ins. |
+| `enrichments` | Optional list of enrichment plug-ins. |
+| `targets` | Array of Salesforce object mappings to upsert. |
+| `targets[].object` | Salesforce object API name. |
+| `targets[].externalId` | External ID field for upsert operations. |
+| `targets[].fieldMap` | Mapping from source column names to Salesforce fields. |
+| `targets[].link` | Optional reference fields linking to previously created objects. |
+| `targets[].postCreateRules` | Optional plug-ins run after record creation. |

--- a/schema/profile_v2.schema.json
+++ b/schema/profile_v2.schema.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://example.com/crm-file-processor/profile_v2.schema.json",
+    "title": "CRM File-Processor – Profile v2",
+    "description": "Declarative configuration for each vendor file feed.",
+    "type": "object",
+    "required": [
+        "parserId",
+        "maxBytes",
+        "maxRows",
+        "rowStateMachineArn",
+        "mapMaxConcurrency",
+        "targets"
+    ],
+    "properties": {
+        "parserId":          { "type": "string", "enum": ["csv_pipe","fixed_width","xlsx_sheet"] },
+        "maxBytes":          { "type": "integer", "minimum": 1 },
+        "maxRows":           { "type": "integer", "minimum": 1 },
+        "rowStateMachineArn":{ "type": "string",  "pattern": "^arn:aws:states:[a-z0-9-]+:\\d{12}:stateMachine:[A-Za-z0-9-_]+$" },
+        "mapMaxConcurrency": { "type": "integer", "minimum": 1, "maximum": 10000 },
+        "rowValidation": {
+            "type": "object",
+            "properties": {
+                "required": { "type": "array", "items": { "type": "string" } },
+                "regex":    { "type": "object", "additionalProperties": { "type": "string" } }
+            },
+            "additionalProperties": false
+        },
+        "preProcessors":  { "type": "array", "items": { "type": "object" } },
+        "enrichments":    { "type": "array", "items": { "type": "object" } },
+        "targets": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["object", "externalId", "fieldMap"],
+                "properties": {
+                    "object":     { "type": "string" },
+                    "externalId": { "type": "string" },
+                    "fieldMap":   { "type": "object", "additionalProperties": { "type": "string" } },
+                    "link":       { "type": "object", "additionalProperties": { "type": "string" } },
+                    "postCreateRules": { "type": "array", "items": { "type": "object" } }
+                },
+                "additionalProperties": false
+            }
+        }
+    },
+    "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add Profile v2 JSON schema
- create Flood QNS sample profiles for dev and prod
- document profile fields in a glossary
- insert guidance on using Profile v2 into all lambda READMEs

## Testing
- `python3 -m jsonschema -i crm/file-profiles/dev/flood_qns.json schema/profile_v2.schema.json`
- `python3 -m jsonschema -i crm/file-profiles/prod/flood_qns.json schema/profile_v2.schema.json`
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_687663c088b883288963dedfa2a4858a