### PR TITLE
Fix CI schema validation step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,15 @@ jobs:
           done
       - name: Validate schema
         run: |
-          pip install jsonschema
-          python - <<'PY'
-          import json, jsonschema, glob
-          schema=json.load(open('schema/profile_v2.schema.json'))
-          for f in glob.glob('sample-profiles/*.json'):
-            data=json.load(open(f))
-            jsonschema.validate(data, schema)
-          print('schema ok')
-          PY
+        pip install jsonschema
+        python - <<'PY'
+        import json, jsonschema, glob
+        schema=json.load(open('schema/profile_v2.schema.json'))
+        for f in glob.glob('sample-profiles/*.json'):
+          data=json.load(open(f))
+          jsonschema.validate(data, schema)
+        print('schema ok')
+PY
       - name: SAM validate
         run: sam validate --region us-east-1
       - name: Ensure bin directory exists


### PR DESCRIPTION
## Summary
- fix heredoc terminator spacing in CI workflow to prevent bash errors

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6876bd033d80832896e25051b219653f